### PR TITLE
Force basic auth in version check

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -30,6 +30,9 @@
         status_code: 200
         body_format: json
         validate_certs: false
+        force_basic_auth: >-
+          {{ lookup('env', 'GH_USER') | default("")  and
+             lookup('env', 'GH_TOKEN') | default("") | bool  }}
         user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
         password: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
       no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"


### PR DESCRIPTION
basic auth is only attempted if the server responds with a 401 status
code, github either sends 200 if rate limit not hit, or 403 if the rate
limit is hit, see: https://docs.ansible.com/ansible/latest/modules/uri_module.html